### PR TITLE
fix(Tabs): support dynamic tabs

### DIFF
--- a/packages/core/src/components/Tabs/Tabs.vue
+++ b/packages/core/src/components/Tabs/Tabs.vue
@@ -107,7 +107,7 @@ import buttonStyles from '@patternfly/react-styles/css/components/Button/button'
 import { classesFromBreakpointProps, type InsetBreakpointProps } from '../../breakpoints';
 import { isElementInView, getUniqueId } from '../../util';
 import { useManagedProp } from '../../use';
-import { watchEffect, nextTick, onMounted, provide, computed, type InjectionKey, type ComputedRef, type Ref, ref, type WritableComputedRef, type HTMLAttributes } from 'vue';
+import { watch, watchEffect, nextTick, onMounted, provide, computed, type InjectionKey, type ComputedRef, type Ref, ref, type WritableComputedRef, type HTMLAttributes } from 'vue';
 import { useOUIAProps, type OUIAProps } from '../../helpers/ouia';
 import AngleLeftIcon from '@vue-patternfly/icons/angle-left-icon';
 import AngleRightIcon from '@vue-patternfly/icons/angle-right-icon';
@@ -159,6 +159,8 @@ watchEffect(() => {
     localActiveKey.value = tabKeys[0].value;
   }
 });
+
+watch(tabKeys, handleScrollButtons, { immediate: true });
 
 onMounted(() => {
   nextTick(handleScrollButtons);


### PR DESCRIPTION
### What?
This PR adds support for dynamic tab lists (using `v-for`).

Right now when using dynamic tabs the scroll buttons will always be shown because the tabs are not yet mounted when the lifecycle hook of the `Tabs` component is executed. Also when adding or removing an arbitrary amount of new `Tab` components the scrollButtons would never be recomputed.

### How?
To sort this out I've added a Mutation Observer which observes the child nodes (tabs) and triggers the scrollButton. handler on changes.

Let me know what you think about this.