### PR TITLE
fix(Tabs): provide idSuffix as string

### DIFF
--- a/packages/core/src/components/Tabs/Tabs.vue
+++ b/packages/core/src/components/Tabs/Tabs.vue
@@ -141,7 +141,7 @@ const tabKeys = provideChildrenTracker(TabsKey);
 provide(TabsProvideKey, {
   variant: props.variant,
   activeKey: localActiveKey,
-  idSuffix: () => props.id,
+  idSuffix: props.id,
   tabListRef,
 });
 


### PR DESCRIPTION
Fixes https://github.com/mtorromeo/vue-patternfly/issues/14


Fixes an issue where the idSuffix was provided as a function instead of a string to the child components. This lead to broken ids being rendered in the DOM. I don't see a reason why this should be passed as a func, so i reckon this is the easiest way to solve the issue.