### PR TITLE
Fixes ToolbarToggleGroup not toggling

### DIFF
--- a/packages/core/src/components/Toolbar/ToolbarToggleGroup.vue
+++ b/packages/core/src/components/Toolbar/ToolbarToggleGroup.vue
@@ -6,7 +6,7 @@
         aria-label="Show Filters"
         :aria-expanded="expanded"
         :aria-haspopup="expanded && isContentPopup"
-        @click="toggleExpanded ?? undefined"
+        @click="toggleExpanded"
       >
         <slot name="icon" />
       </pf-button>


### PR DESCRIPTION
`toggleExpanded ?? undefined` resolves to an expression where toggleExpanded is not called. Vue's event binding can handle null or undefined values gracefully making the ?? undefined unnecessary.