### PR TITLE
[v6] Fix rem calculations

### DIFF
--- a/packages/core/src/components/OverflowMenu/OverflowMenu.vue
+++ b/packages/core/src/components/OverflowMenu/OverflowMenu.vue
@@ -8,7 +8,7 @@
 export const OverflowMenuIsBelowBreakpointKey = Symbol('OverflowMenuIsBelowBreakpointKey') as InjectionKey<Ref<boolean> | boolean>;
 
 interface Props extends OUIAProps, /* @vue-ignore */ HTMLAttributes {
-  breakpoint: keyof typeof globalBreakpoints;
+  breakpoint: keyof typeof globalWidthBreakpoints;
 }
 </script>
 
@@ -16,7 +16,7 @@ interface Props extends OUIAProps, /* @vue-ignore */ HTMLAttributes {
 import styles from '@patternfly/react-styles/css/components/OverflowMenu/overflow-menu';
 import { watch, ref, provide, type HTMLAttributes, type InjectionKey, type Ref } from 'vue';
 import { useWindowSize } from '@vueuse/core';
-import { globalBreakpoints } from '../Toolbar/common';
+import { globalWidthBreakpoints } from '../../constants';
 import { useOUIAProps, type OUIAProps } from '../../helpers/ouia';
 
 defineOptions({
@@ -36,8 +36,6 @@ provide(OverflowMenuIsBelowBreakpointKey, isBelowBreakpoint);
 const { width: windowWidth } = useWindowSize();
 
 watch(windowWidth, (width) => {
-  const breakpointPx = globalBreakpoints[props.breakpoint];
-  const breakpointWidth = Number(breakpointPx.toString().replace('px', ''));
-  isBelowBreakpoint.value = width < breakpointWidth;
+  isBelowBreakpoint.value = width < globalWidthBreakpoints[props.breakpoint];
 }, { immediate: true });
 </script>

--- a/packages/core/src/components/Page/Page.vue
+++ b/packages/core/src/components/Page/Page.vue
@@ -82,7 +82,7 @@ interface Props extends OUIAProps, /* @vue-ignore */ HTMLAttributes {
 
 <script lang="ts" setup>
 import styles from '@patternfly/react-styles/css/components/Page/page';
-import globalBreakpointXl from '@patternfly/react-tokens/dist/esm/t_global_breakpoint_xl';
+import { globalWidthBreakpoints } from '../../constants';
 import { createReusableTemplate, useElementSize, useWindowSize } from '@vueuse/core';
 import { ref, provide, computed, watch, type Ref, type InjectionKey, type WritableComputedRef, type HTMLAttributes, useTemplateRef, type ComponentPublicInstance } from 'vue';
 import PfDrawer from '../Drawer/Drawer.vue';
@@ -143,7 +143,7 @@ provide(PageSidebarOpenKey, sidebarOpen);
 const { width: windowWidth } = useWindowSize();
 
 watch(windowWidth, (width) => {
-  mobileView.value = width < Number.parseInt(globalBreakpointXl.value, 10);
+  mobileView.value = width < globalWidthBreakpoints.xl;
   emit('pageResize', { mobileView: mobileView.value, windowSize: width });
 }, { immediate: true });
 

--- a/packages/core/src/components/Toolbar/common.ts
+++ b/packages/core/src/components/Toolbar/common.ts
@@ -4,8 +4,8 @@ import globalBreakpointXl from '@patternfly/react-tokens/dist/js/t_global_breakp
 import globalBreakpoint2xl from '@patternfly/react-tokens/dist/js/t_global_breakpoint_2xl';
 
 export const globalBreakpoints = {
-  md: parseInt(globalBreakpointMd.value),
-  lg: parseInt(globalBreakpointLg.value),
-  xl: parseInt(globalBreakpointXl.value),
-  '2xl': parseInt(globalBreakpoint2xl.value),
+  md: parseInt(globalBreakpointMd.value) * 16,
+  lg: parseInt(globalBreakpointLg.value) * 16,
+  xl: parseInt(globalBreakpointXl.value) * 16,
+  '2xl': parseInt(globalBreakpoint2xl.value) * 16,
 };


### PR DESCRIPTION
`16` is default for browsers -> `getComputedStyle(document.documentElement).fontSize`

Currently values are in `rem` so it must be multiply by `16`

`OverflowMenu` used wrong import so aligned with `patternfly-eact` version  and now alos `sm` breakpoint is supported