### PR TITLE
fix: update peerDependency for @useuse and added package.json to exports

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,6 +6,7 @@
     "dist"
   ],
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "types": "./dist/main.d.ts",
       "import": "./dist/main.js"
@@ -59,9 +60,9 @@
     "vue-tsc": "^3.2.5"
   },
   "peerDependencies": {
-    "@vueuse/core": "^13",
-    "@vueuse/integrations": "^13",
-    "@vueuse/shared": "^13",
+    "@vueuse/core": "^13 || ^14",
+    "@vueuse/integrations": "^13 || ^14",
+    "@vueuse/shared": "^13 || ^14",
     "focus-trap": "*"
   },
   "packageManager": "pnpm@10.32.1+sha512.a706938f0e89ac1456b6563eab4edf1d1faf3368d1191fc5c59790e96dc918e4456ab2e67d613de1043d2e8c81f87303e6b40d4ffeca9df15ef1ad567348f2be"

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -6,6 +6,7 @@
     "dist"
   ],
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
@@ -48,6 +49,6 @@
   },
   "peerDependencies": {
     "@vue-patternfly/core": "workspace:^",
-    "@vueuse/core": "^13"
+    "@vueuse/core": "^13 || ^14"
   }
 }


### PR DESCRIPTION
Added @useuse 14 to peerDependency and fix error during build

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports" in /home/ ... /node_modules/@vue-patternfly/core/package.json
    at exportsNotFound (node:internal/modules/esm/resolve:314:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:657:13)
    at resolveExports (node:internal/modules/cjs/loader:685:36)
    at Module._findPath (node:internal/modules/cjs/loader:752:31)
    at Module._resolveFilename (node:internal/modules/cjs/loader:1441:27)
    at defaultResolveImpl (node:internal/modules/cjs/loader:1066:19)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1071:22)
```